### PR TITLE
Add support for custom_code node type in workflow file processing

### DIFF
--- a/api/workflow/workflow.py
+++ b/api/workflow/workflow.py
@@ -159,7 +159,7 @@ async def node_run(data: WorkflowsNodeRunSchema,
             await asyncio.sleep(0.1)
         result = task.get(timeout=100)
 
-        if node_data.data['type'] == 'skill':
+        if node_data.data['type'] in ['skill', 'custom_code', 'end']:
             node_data_dict = node_data.to_dict()
             file_list = extract_file_list_from_skill_output(result['data']['outputs'], node_data_dict["data"]["output"])
             result['data']['file_list'] = file_list

--- a/core/database/models/workspaces.py
+++ b/core/database/models/workspaces.py
@@ -211,7 +211,7 @@ class Workspaces(MySQL):
                     elif app_node['node_type'] == 'recursive_task_generation' or (app_node['node_type'] == 'recursive_task_execution' and not app_node['task_id']):
                         task_dict = json.loads(get_first_variable_value(create_variable_from_dict(outputs)))
                         app_node['outputs_md'] = create_recursive_task_category_from_dict(task_dict).to_markdown()
-                    elif app_node['node_type'] in ['skill', 'end']:
+                    elif app_node['node_type'] in ['skill', 'custom_code', 'end']:
                         file_list = extract_file_list_from_skill_output(app_node['outputs'], app_node['node_graph']['data']['output'])
                         # file_list = []
                         # skill_output = app_node['outputs']

--- a/task/workflow_run.py
+++ b/task/workflow_run.py
@@ -257,7 +257,7 @@ def push_workflow_debug_message(
         elif node.data['type'] in ['recursive_task_generation', 'recursive_task_execution']:
             task_dict = json.loads(get_first_variable_value(create_variable_from_dict(outputs)))
             node_exec_data['outputs_md'] = create_recursive_task_category_from_dict(task_dict).to_markdown()
-        elif node.data['type'] in ['skill', 'end']:
+        elif node.data['type'] in ['skill', 'custom_code', 'end']:
             file_list = []
             skill_output = node_exec_data['outputs']
             storage_url = f"{os.getenv('STORAGE_URL', '')}/file"


### PR DESCRIPTION
- Update workflow processing to handle 'custom_code' node type alongside 'skill' and 'end' nodes
- Modify file list extraction logic in multiple files to include custom_code nodes
- Ensure consistent file handling across workflow run and database model components