### PR TITLE
fix: rename default agent variable

### DIFF
--- a/web/src/locales/en-US/agent.ts
+++ b/web/src/locales/en-US/agent.ts
@@ -40,6 +40,7 @@ export default {
     'agent.pleaseselect': 'Please select',
     'agent.functiondescription': 'Function Description',
     'agent.inputvariable': 'Input Variable',
+    'agent.inputvariable.default.display': 'Default variable',
     'agent.add': 'Add ',
     'agent.addAbility': 'Add Ability',
     'agent.associatedknowledgebase': 'Link Knowledge Base',

--- a/web/src/locales/zh-CN/agent.ts
+++ b/web/src/locales/zh-CN/agent.ts
@@ -40,6 +40,7 @@ export default {
     'agent.pleaseselect': '请选择',
     'agent.functiondescription': '职能描述',
     'agent.inputvariable': '输入变量',
+    'agent.inputvariable.default.display': '默认变量',
     'agent.add': '添加',
     'agent.addAbility': '添加能力',
     'agent.associatedknowledgebase': '关联知识库',

--- a/web/src/pages/Creation/Agents/index.tsx
+++ b/web/src/pages/Creation/Agents/index.tsx
@@ -110,6 +110,22 @@ const Agents: React.FC = () => {
             },
         },
     ];
+    const createDefaultInputVariables = () => {
+        const defaultDisplayName = intl.formatMessage({
+            id: 'agent.inputvariable.default.display',
+        });
+        const inputVariables = new ObjectVariable('input', '', '');
+        const defaultVariable = new AgentsVariable(
+            'default_var',
+            'string',
+            '',
+            defaultDisplayName,
+            true,
+            48,
+        );
+        inputVariables.addProperty('default_var', defaultVariable);
+        return inputVariables.toObject();
+    };
     useEffect(() => {
         let params = new URLSearchParams(window.location.search);
         if (!params.get('app_id')) {
@@ -137,6 +153,12 @@ const Agents: React.FC = () => {
             res = await agentdefault();
         }
         const data = res.data;
+        if (
+            !data.agent.input_variables ||
+            _.isEmpty(data.agent.input_variables?.properties)
+        ) {
+            data.agent.input_variables = createDefaultInputVariables();
+        }
         const repositoryID = res.data?.agent_dataset_relation_list?.map((item: any) => {
             return item.dataset_id;
         });


### PR DESCRIPTION
## Summary
- rename the auto-generated default input variable to use the `default_var` identifier
- localize the default input variable label as "Default variable" in English and "默认变量" in Chinese

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68db58102d2483328d37d674d2014954