### PR TITLE
feat: support fullscreen editing for agent function description

### DIFF
--- a/web/src/locales/en-US/agent.ts
+++ b/web/src/locales/en-US/agent.ts
@@ -39,6 +39,8 @@ export default {
     'agent.LLMmodel': 'LLM Model',
     'agent.pleaseselect': 'Please select',
     'agent.functiondescription': 'Function Description',
+    'agent.functiondescription.fullscreen': 'Fullscreen edit',
+    'agent.functiondescription.exitfullscreen': 'Exit fullscreen',
     'agent.inputvariable': 'Input Variable',
     'agent.add': 'Add ',
     'agent.addAbility': 'Add Ability',

--- a/web/src/locales/zh-CN/agent.ts
+++ b/web/src/locales/zh-CN/agent.ts
@@ -39,6 +39,8 @@ export default {
     'agent.LLMmodel': 'LLM模型',
     'agent.pleaseselect': '请选择',
     'agent.functiondescription': '职能描述',
+    'agent.functiondescription.fullscreen': '全屏编辑',
+    'agent.functiondescription.exitfullscreen': '退出全屏',
     'agent.inputvariable': '输入变量',
     'agent.add': '添加',
     'agent.addAbility': '添加能力',


### PR DESCRIPTION
## Summary
- add a fullscreen overlay editor for the agent function description field with synchronized content
- display a fullscreen toggle within the existing textarea and disable background scrolling while expanded
- extend i18n resources with labels for the new fullscreen controls

## Testing
- npm run lint:js *(fails: existing lint configuration reports thousands of unrelated prettier/prettier and eqeqeq issues)*

------
https://chatgpt.com/codex/tasks/task_e_68e86beb6f808332ad711e649819a7a4